### PR TITLE
Build wheels for all platforms on Github actions

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,44 @@
+
+name: Build
+
+on: [workflow_dispatch]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.1.1
+
+      # We need docker's cross architecture emulation to build ARM wheels.
+      - if: startsWith(matrix.os, 'ubuntu')
+        uses: crazy-max/ghaction-docker-buildx@v3.3.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        # Configuration is passed via environment variables. See
+        # https://cibuildwheel.readthedocs.io/en/stable/options/
+        env:
+          # Platform options
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.6,<3.10"
+          CIBW_SKIP: "pp*"  # Skip PyPy.
+          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
+          # Testing
+          CIBW_TEST_REQUIRES: "-r tests/requirements.txt"
+          CIBW_TEST_COMMAND: pytest {package}/tests
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl


### PR DESCRIPTION
As promised, here's something to build all the wheels we need to go on PyPI. An example of it in action can be found [here](https://github.com/bwoodsend/pyFMR-Fast-quadric-Mesh-Reduction/actions/runs/1119777055). The wheels it built are downloadable at the bottom of that page.