### PR TITLE
fix(installation): missing files in sdist + formatting

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
- recursive-include pyFMR * 
+include VERSION
+include LICENSE
+include pyfqmr/Simplify.h
+include pyfqmr/Simplify.pyx

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ setup(
         "Topic :: Scientific/Engineering",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English"
-        ]
+        ],
+    long_description_content_type='text/markdown',
     )
 
 


### PR DESCRIPTION
Hi Kramer84,

I'm looking into using this package for high throughput mesh simplification and I found some issues with the version on PyPI that prevented installation. The problem was the MANIFEST.in was not spelled well and several necessary files are not included in the sdist. 

I also added a tag to make sure that PyPI understands how to parse the README.md. I'll be happy to contribute any more fixes as I go along.

Thanks for this great package!