### PR TITLE
redesign: simplify_mesh only prints when verbose is true

### DIFF
--- a/pyfqmr/Simplify.pyx
+++ b/pyfqmr/Simplify.pyx
@@ -137,8 +137,11 @@ cdef class Simplify :
                       lossless, threshold_lossless, preserve_border)
         t_end = _time()
         N_end = getFaces().size()
-        print('simplified mesh in {} seconds from {} to {} triangles'.format(round(t_end-t_start,4), N_start, N_end))
 
+        if verbose:
+            print('simplified mesh in {} seconds from {} to {} triangles'.format(
+                round(t_end-t_start,4), N_start, N_end)
+            )
 
 cdef vector[vector[double]] setVerticesNogil(double[:,:] vertices, vector[vector[double]] vector_vertices )nogil:
     """nogil function for filling the vector of vertices, "vector_vertices",


### PR DESCRIPTION
I'm thinking of using this as part of a computational pipeline where timing printouts are helpful but usually the process should be silent.