### PR TITLE
perf: accelerates Simplify.getMesh

### DIFF
--- a/pyfqmr/Simplify.pyx
+++ b/pyfqmr/Simplify.pyx
@@ -63,7 +63,7 @@ cdef class Simplify :
         cdef size_t N_n = self.normals_cpp.size()
         cdef np.ndarray[int, ndim=2] faces = _REF.faces.astype(dtype=np.int32, subok=False, copy=True)[:N_t, :] 
         cdef np.ndarray[double, ndim=2] verts = _REF.verts.astype(dtype=np.float64, subok=False, copy=True)[:N_v, :] 
-        cdef np.ndarray[double, ndim=2] norms = _REF.faces.astype(dtype=np.float64, subok=False, copy=True)[:N_n, :] 
+        cdef np.ndarray[double, ndim=2] norms = np.zeros((N_n, 3), dtype=np.float64)
 
         cdef size_t i = 0
         cdef size_t j = 0

--- a/pyfqmr/Simplify.pyx
+++ b/pyfqmr/Simplify.pyx
@@ -61,19 +61,19 @@ cdef class Simplify :
         cdef size_t N_t = self.triangles_cpp.size()
         cdef size_t N_v = self.vertices_cpp.size()
         cdef size_t N_n = self.normals_cpp.size()
-        cdef np.ndarray[int, ndim=2] faces = _REF.faces.astype(dtype=np.int32, subok=False, copy=True)[:N_t, :] 
-        cdef np.ndarray[double, ndim=2] verts = _REF.verts.astype(dtype=np.float64, subok=False, copy=True)[:N_v, :] 
+        cdef np.ndarray[int, ndim=2] faces = np.zeros((N_t, 3), dtype=np.int32)
+        cdef np.ndarray[double, ndim=2] verts = np.zeros((N_v, 3), dtype=np.float64)
         cdef np.ndarray[double, ndim=2] norms = np.zeros((N_n, 3), dtype=np.float64)
 
         cdef size_t i = 0
         cdef size_t j = 0
 
-        for i in range(N_v):
-            for j in range(3):
-                verts[i,j] = self.vertices_cpp[i][j]
         for i in range(N_t):
             for j in range(3):
                 faces[i,j] = self.triangles_cpp[i][j]
+        for i in range(N_v):
+            for j in range(3):
+                verts[i,j] = self.vertices_cpp[i][j]
         for i in range(N_n):
             for j in range(3):
                 norms[i,j] = self.normals_cpp[i][j]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,5 @@ requires = [
   "setuptools",
   "wheel",
   "cython",
+  "oldest-supported-numpy",
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup
 from setuptools.extension import Extension
 
+import numpy as np
+
 # setup file based on:  
 # https://github.com/AshleySetter/HowToPackageCythonAndCppFuncs
 
@@ -32,6 +34,7 @@ setup(
         [
         'pyfqmr'
         ],
+    include_dirs=[ np.get_include() ],
     ext_modules      = extensions,
     long_description = readme,
     install_requires = [],

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ extensions = [
     Extension(
     name         = "pyfqmr.Simplify",        # name/path of generated .so file
     sources      = ["pyfqmr/Simplify.pyx"],  # cython generated cpp file
+    include_dirs = [ np.get_include() ],    # ensure numpy can find headers
     language     = "c++"),                  # tells python that the language of the extension is c++
     ]
 
@@ -34,7 +35,6 @@ setup(
         [
         'pyfqmr'
         ],
-    include_dirs=[ np.get_include() ],
     ext_modules      = extensions,
     long_description = readme,
     install_requires = [],

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 import pyfqmr
 
+import numpy as np
+
 # Get the /example folder at the root of this repo
 EXAMPLES_DIR = Path(__file__, "..", "..", "example").resolve()
 
@@ -17,3 +19,16 @@ def test_example():
     assert len(faces) / len(bunny.faces) == pytest.approx(.5, rel=.05)
     simplified = tr.Trimesh(vertices, faces, normals)
     assert simplified.area == pytest.approx(simplified.area, rel=.05)
+
+def test_empty():
+    verts = np.zeros((0,3), dtype=np.float32)
+    faces = np.zeros((0,3), dtype=np.float32)
+
+    simp = pyfqmr.Simplify()
+    simp.setMesh(verts, faces)
+    simp.simplify_mesh()
+    vertices, faces, normals = simp.getMesh()
+    
+    assert len(vertices) == 0
+    assert len(faces) == 0
+    assert len(normals) == 0

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -13,8 +13,7 @@ def test_example():
     simp.setMesh(bunny.vertices, bunny.faces)
     simp.simplify_mesh(len(bunny.faces) // 2)
     vertices, faces, normals = simp.getMesh()
-    print(vertices)
-
+    
     assert len(faces) / len(bunny.faces) == pytest.approx(.5, rel=.05)
     simplified = tr.Trimesh(vertices, faces, normals)
     assert simplified.area == pytest.approx(simplified.area, rel=.05)

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -13,6 +13,7 @@ def test_example():
     simp.setMesh(bunny.vertices, bunny.faces)
     simp.simplify_mesh(len(bunny.faces) // 2)
     vertices, faces, normals = simp.getMesh()
+    print(vertices)
 
     assert len(faces) / len(bunny.faces) == pytest.approx(.5, rel=.05)
     simplified = tr.Trimesh(vertices, faces, normals)


### PR DESCRIPTION
Adds numpy dependency.

Python loops are very slow and Cython doesn't optimize them without extra guidance. 

getMesh on Bunny master branch (seconds, 5 trials):
```
0.10924196243286133
0.10519695281982422
0.1050729751586914
0.10522007942199707
0.10472702980041504
```

This branch:
```
0.0672907829284668
0.0617070198059082
0.06187701225280762
0.06154680252075195
0.0612490177154541
```