### PR TITLE
Fix issue 24

### DIFF
--- a/pyfqmr/Simplify.h
+++ b/pyfqmr/Simplify.h
@@ -635,37 +635,6 @@ namespace Simplify
       }
       triangles.resize(dst);
     }
-    //
-    // Init Quadrics by Plane & Edge Errors
-    //
-    // required at the beginning ( iteration == 0 )
-    // recomputing during the simplification is not required,
-    // but mostly improves the result for closed meshes
-    //
-    if( iteration == 0 )
-    {
-      loopi(0,vertices.size())
-      vertices[i].q=SymetricMatrix(0.0);
-
-      loopi(0,triangles.size())
-      {
-        Triangle &t=triangles[i];
-        vec3f n,p[3];
-        loopj(0,3) p[j]=vertices[t.v[j]].p;
-        n.cross(p[1]-p[0],p[2]-p[0]);
-        n.normalize();
-        t.n=n;
-        loopj(0,3) vertices[t.v[j]].q =
-          vertices[t.v[j]].q+SymetricMatrix(n.x,n.y,n.z,-n.dot(p[0]));
-      }
-      loopi(0,triangles.size())
-      {
-        // Calc Edge Error
-        Triangle &t=triangles[i];vec3f p;
-        loopj(0,3) t.err[j]=calculate_error(t.v[j],t.v[(j+1)%3],p);
-        t.err[3]=min(t.err[0],min(t.err[1],t.err[2]));
-      }
-    }
 
     // Init Reference ID list
     loopi(0,vertices.size())
@@ -739,6 +708,39 @@ namespace Simplify
           vertices[vids[j]].border=1;
       }
     }
+
+    //
+    // Init Quadrics by Plane & Edge Errors
+    //
+    // required at the beginning ( iteration == 0 )
+    // recomputing during the simplification is not required,
+    // but mostly improves the result for closed meshes
+    //
+    if( iteration == 0 )
+    {
+      loopi(0,vertices.size())
+      vertices[i].q=SymetricMatrix(0.0);
+
+      loopi(0,triangles.size())
+      {
+        Triangle &t=triangles[i];
+        vec3f n,p[3];
+        loopj(0,3) p[j]=vertices[t.v[j]].p;
+        n.cross(p[1]-p[0],p[2]-p[0]);
+        n.normalize();
+        t.n=n;
+        loopj(0,3) vertices[t.v[j]].q =
+          vertices[t.v[j]].q+SymetricMatrix(n.x,n.y,n.z,-n.dot(p[0]));
+      }
+      loopi(0,triangles.size())
+      {
+        // Calc Edge Error
+        Triangle &t=triangles[i];vec3f p;
+        loopj(0,3) t.err[j]=calculate_error(t.v[j],t.v[(j+1)%3],p);
+        t.err[3]=min(t.err[0],min(t.err[1],t.err[2]));
+      }
+    }
+
   }
 
   // Finally compact mesh before exiting


### PR DESCRIPTION
This resolves [issue 24](https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification/issues/24). The order of initialization is changed, so that the edge error is calculated after the borders have been defined.  This error will not be obvious if a compiler initializes the border array to zero. In my experience, the issues are very obvious with the Clang compiler.

You can validate the issue and the resolution by downloading the [face.zip](https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification/issues/24) mesh:

```
import pyfqmr
import trimesh as tr
face = tr.load_mesh('~/face.obj')
mesh_simplifier = pyfqmr.Simplify()
mesh_simplifier.setMesh(face.vertices, face.faces)
mesh_simplifier.simplify_mesh(target_count = 164600, aggressiveness=7, preserve_border=True, verbose=10)
vtx, fc, normals = mesh_simplifier.getMesh()
mesh = tr.Trimesh(vertices=vtx,faces=fc)
mesh.export("~/simplified.obj")
```