### PR TITLE
Specify Setuptools as build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
+build-backend = "setuptools.build_meta"
 requires = [
   "setuptools",
-  "wheel",
   "cython",
   # NumPy must be locked in order to support 1.x and 2.x
   "numpy==2.0; python_version >= '3.9'",


### PR DESCRIPTION
Instead of default legacy Setuptools backend. See [packaging docs](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#declaring-the-build-backend).

Also removes explicit `wheel` requirement, as it is a dependency of Setuptools.