### PR TITLE
Also build sdist in CI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,6 +4,25 @@ name: Build
 on: [workflow_dispatch]
 
 jobs:
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+
+      - name: Install build
+        run: python -m pip install build
+
+      - name: Build sdist
+        run: python -m build --sdist --output-dir ./dist .
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./dist/*.tar.gz
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
So package can be built on platforms which don't have wheels