### PR TITLE
Use standard-library logging for verbose logging

### DIFF
--- a/pyfqmr/Simplify.h
+++ b/pyfqmr/Simplify.h
@@ -342,7 +342,7 @@ namespace Simplify
   //
 
   void simplify_mesh(int target_count, int update_rate=5, double agressiveness=7, 
-                     bool verbose=false, int max_iterations=100, double alpha = 0.000000001, 
+                     void (*log)(char*, int)=NULL, int max_iterations=100, double alpha = 0.000000001,
                      int K = 3, bool lossless=false, double threshold_lossless = 0.0001,
                      bool preserve_border = false)
   {
@@ -381,8 +381,10 @@ namespace Simplify
       if(lossless) threshold = threshold_lossless ;
 
       // target number of triangles reached ? Then break
-      if ((verbose) && (iteration%5==0)) {
-        printf("iteration %d - triangles %d threshold %g\n",iteration,triangle_count-deleted_triangles, threshold);
+      if ((log) && (iteration%5==0)) {
+        char message[128];
+        snprintf(message, 127, "iteration %d - triangles %d threshold %g",iteration,triangle_count-deleted_triangles, threshold);
+        log(message, 128);
       }
 
       // remove vertices & mark deleted triangles

--- a/pyfqmr/Simplify.pyx
+++ b/pyfqmr/Simplify.pyx
@@ -6,7 +6,6 @@ from libcpp.vector cimport vector
 from libcpp cimport bool
 
 from time import time as _time
-from logging import getLogger
 
 cimport numpy as np
 import numpy as np
@@ -152,6 +151,8 @@ cdef class Simplify :
         N_end = getFaces().size()
 
         if verbose:
+            from logging import getLogger
+
             logger = getLogger("pyfqmr")
             logger.debug('simplified mesh in {} seconds from {} to {} triangles'.format(
                 round(t_end-t_start,4), N_start, N_end)

--- a/pyfqmr/Simplify.pyx
+++ b/pyfqmr/Simplify.pyx
@@ -5,13 +5,10 @@ cimport cython
 from libcpp.vector cimport vector
 from libcpp cimport bool
 
-from logging import getLogger
 from time import time as _time
 
 cimport numpy as np
 import numpy as np
-
-logger = getLogger("pyfqmr")
 
 class _hidden_ref(object):
     """Hidden Python object to keep a reference to our numpy arrays
@@ -33,7 +30,9 @@ cdef extern from "Simplify.h" namespace "Simplify" :
 
 cdef void log_message(char* message, int length) noexcept:
     if message is not NULL:
-        logger.debug(message.decode("utf-8"))
+        from logging import getLogger
+
+        getLogger("pyfqmr").debug(message.decode("utf-8"))
 
 cdef class Simplify : 
 
@@ -165,7 +164,9 @@ cdef class Simplify :
         N_end = getFaces().size()
 
         if verbose:
-            logger.debug('simplified mesh in {} seconds from {} to {} triangles'.format(
+            from logging import getLogger
+
+            getLogger("pyfqmr").debug('simplified mesh in {} seconds from {} to {} triangles'.format(
                 round(t_end-t_start,4), N_start, N_end)
             )
 

--- a/pyfqmr/Simplify.pyx
+++ b/pyfqmr/Simplify.pyx
@@ -6,6 +6,7 @@ from libcpp.vector cimport vector
 from libcpp cimport bool
 
 from time import time as _time
+from logging import getLogger
 
 cimport numpy as np
 import numpy as np
@@ -151,7 +152,8 @@ cdef class Simplify :
         N_end = getFaces().size()
 
         if verbose:
-            print('simplified mesh in {} seconds from {} to {} triangles'.format(
+            logger = getLogger("pyfqmr")
+            logger.debug('simplified mesh in {} seconds from {} to {} triangles'.format(
                 round(t_end-t_start,4), N_start, N_end)
             )
 

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -1,9 +1,12 @@
+from logging import root as root_logger, DEBUG
 from pathlib import Path
 
 import pytest
 import pyfqmr
 
 import numpy as np
+
+root_logger.setLevel(DEBUG)
 
 # Get the /example folder at the root of this repo
 EXAMPLES_DIR = Path(__file__, "..", "..", "example").resolve()


### PR DESCRIPTION
Instead of `print` - allows for more configurability by the user