### PR TITLE
Move project metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,43 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools",
+  "setuptools >= 61.0",
   "cython",
   # NumPy must be locked in order to support 1.x and 2.x
   "numpy==2.0; python_version >= '3.9'",
   # Unless building for a Python version that NumPy 2.x doesn't support
   "oldest-supported-numpy; python_version <= '3.8'",
 ]
+
+[project]
+name = "pyfqmr"
+authors = [
+  { name = "kramer84" },
+]
+description = "cython wrapper around C++ library for fast triangular mesh reduction"
+readme = "README.rst"
+license = { text = "MIT" }
+
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Intended Audience :: Science/Research",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Topic :: Scientific/Engineering",
+  "License :: OSI Approved :: MIT License",
+  "Natural Language :: English",
+]
+
+dependencies = ["numpy"]
+
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/Kramer84/pyfqmr-Fast-quadric-Mesh-Reduction"
+
+[tool.setuptools]
+include-package-data = true
+packages = ["pyfqmr"]
+
+[tool.setuptools.dynamic]
+version = { file = "VERSION" }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description_file = README.rst

--- a/setup.py
+++ b/setup.py
@@ -6,15 +6,6 @@ import numpy as np
 # setup file based on:  
 # https://github.com/AshleySetter/HowToPackageCythonAndCppFuncs
 
-
-# load version
-with open("VERSION", 'r') as f_vers:
-    version = f_vers.read()
-
-# load readme
-with open('README.rst') as f_read:
-    readme = f_read.read()
-
 extensions = [
     Extension(
     name         = "pyfqmr.Simplify",        # name/path of generated .so file
@@ -24,32 +15,7 @@ extensions = [
     ]
 
 setup(
-    name        = "pyfqmr",
-    version     = version,
-    description = "cython wrapper around C++ library for fast triangular mesh reduction",
-    author      = "kramer84",
-    url         = "https://github.com/Kramer84/pyfqmr-Fast-quadric-Mesh-Reduction",
-    license     = 'MIT',
-    include_package_data = True,
-    packages = 
-        [
-        'pyfqmr'
-        ],
     ext_modules      = extensions,
-    long_description = readme,
-    install_requires = [
-        "numpy",
-    ],
-    classifiers = 
-        [
-        "Development Status :: 2 - Pre-Alpha",
-        "Intended Audience :: Science/Research",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Topic :: Scientific/Engineering",
-        "License :: OSI Approved :: MIT License",
-        "Natural Language :: English"
-        ],
     )
 
 


### PR DESCRIPTION
To better conform to modern standards and make the metadata static. See [Setuptools docs](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html) and [Python packaging docs](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/).