### PR TITLE
Use PEP 517 interface to build from source

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Run:
 
 .. code:: bash
 
-    python setup.py install
+    pip install .
 
 Usage:
 ~~~~~~


### PR DESCRIPTION
Using `python setup.py` as a CLI is deprecated, and will soon be removed. See [Setuptools docs](https://setuptools.pypa.io/en/latest/deprecated/commands.html) and [Python packaging docs](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/).