### PR TITLE
Require NumPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,9 @@ setup(
         ],
     ext_modules      = extensions,
     long_description = readme,
-    install_requires = [],
+    install_requires = [
+        "numpy",
+    ],
     classifiers = 
         [
         "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
As a runtime dependency (which it seems to be).

There might be a way to not require NumPy with some Cython magic, but I'm not familiar with it.